### PR TITLE
Phase 5: bundle analyzer, structured data, a11y lint, Lighthouse

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,18 @@
 {
-  "extends": ["next/core-web-vitals"],
+  "extends": ["next/core-web-vitals", "plugin:jsx-a11y/recommended"],
+  "plugins": ["jsx-a11y"],
   "rules": {
     "@next/next/no-html-link-for-pages": "off",
-    "react-hooks/exhaustive-deps": "off"
+    "react-hooks/exhaustive-deps": "off",
+    // Phase 5 introduces jsx-a11y; initially treat violations as warnings to avoid blocking builds
+    "jsx-a11y/click-events-have-key-events": "warn",
+    "jsx-a11y/no-static-element-interactions": "warn",
+    "jsx-a11y/no-noninteractive-element-interactions": "warn",
+    "jsx-a11y/no-noninteractive-tabindex": "warn",
+    "jsx-a11y/interactive-supports-focus": "warn",
+    "jsx-a11y/media-has-caption": "warn",
+    "jsx-a11y/label-has-associated-control": "warn",
+    "jsx-a11y/heading-has-content": "warn",
+    "jsx-a11y/no-redundant-roles": "warn"
   }
 }

--- a/app/blog/rss.xml/route.ts
+++ b/app/blog/rss.xml/route.ts
@@ -2,6 +2,8 @@
 import { NextResponse } from 'next/server';
 import { getAllPosts } from '@/lib/blog';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET() {
   const posts = await getAllPosts();
   const site = process.env.NEXT_PUBLIC_SITE_URL || 'https://cloudfix.com';

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import "./globals.css";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import ServiceWorkerRegistrar from '@/components/ServiceWorkerRegistrar';
+import { StructuredData } from '@/components/StructuredData';
 
 const inter = Inter({ subsets: ["latin"], display: 'swap' });
 
@@ -51,6 +52,18 @@ export default function RootLayout({
         <link rel="preconnect" href="https://www.googletagmanager.com" crossOrigin="anonymous" />
       </head>
       <body className={`${inter.className} antialiased`}>
+        <StructuredData
+          type="Organization"
+          data={{
+            name: 'CloudFix',
+            url: process.env.NEXT_PUBLIC_SITE_URL || 'https://cloudfix.com',
+            logo: `${process.env.NEXT_PUBLIC_SITE_URL || 'https://cloudfix.com'}/images/logo.png`,
+            sameAs: [
+              'https://twitter.com/cloudfix',
+              'https://www.linkedin.com/company/cloudfix',
+            ],
+          }}
+        />
         {GA_ID && (
           <>
             <Script src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`} strategy="afterInteractive" />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -57,7 +57,7 @@ export default function RootLayout({
           data={{
             name: 'CloudFix',
             url: process.env.NEXT_PUBLIC_SITE_URL || 'https://cloudfix.com',
-            logo: `${process.env.NEXT_PUBLIC_SITE_URL || 'https://cloudfix.com'}/images/logo.png`,
+            logo: `${process.env.NEXT_PUBLIC_SITE_URL || 'https://cloudfix.com'}/images/CloudFix_Logo_Color.png`,
             sameAs: [
               'https://twitter.com/cloudfix',
               'https://www.linkedin.com/company/cloudfix',

--- a/app/podcast/rss.xml/route.ts
+++ b/app/podcast/rss.xml/route.ts
@@ -2,6 +2,8 @@
 import { NextResponse } from 'next/server';
 import { getAllEpisodes } from '@/lib/podcast';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET() {
   const eps = await getAllEpisodes();
   const site = process.env.NEXT_PUBLIC_SITE_URL || 'https://cloudfix.com';

--- a/components/StructuredData.tsx
+++ b/components/StructuredData.tsx
@@ -1,0 +1,22 @@
+// ABOUTME: Lightweight helper for injecting JSON-LD structured data
+// ABOUTME: Renders a script tag with type application/ld+json
+export interface StructuredDataProps {
+  type: string;
+  data: Record<string, any>;
+}
+
+export function StructuredData({ type, data }: StructuredDataProps): JSX.Element {
+  const json = {
+    '@context': 'https://schema.org',
+    '@type': type,
+    ...data,
+  };
+  return (
+    <script
+      type="application/ld+json"
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(json) }}
+    />
+  );
+}
+

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -88,7 +88,7 @@ export async function getPostBySlug(slug: string): Promise<BlogPost | null> {
       if (stat.isDirectory()) {
         const found = findMdxFile(fullPath, targetSlug);
         if (found) return found;
-      } else if (entry === `${targetSlug}.mdx`) {
+      } else if (fullPath.endsWith(`${targetSlug}.mdx`)) {
         return fullPath;
       }
     }

--- a/next.config.js
+++ b/next.config.js
@@ -10,9 +10,12 @@ const withMDX = require('@next/mdx')({
     rehypePlugins: [rehypeSlug, rehypeHighlight],
   },
 });
+const withBundleAnalyzer = require('@next/bundle-analyzer')({
+  enabled: process.env.ANALYZE === 'true',
+});
 
 /** @type {import('next').NextConfig} */
-const nextConfig = withMDX({
+const nextConfig = withBundleAnalyzer(withMDX({
   images: {
     remotePatterns: [
       {
@@ -22,6 +25,8 @@ const nextConfig = withMDX({
     ],
   },
   pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],
+  compress: true,
+  poweredByHeader: false,
   webpack: (config) => {
     // Ensure TS path alias '@/*' resolves in Webpack too
     config.resolve.alias = {
@@ -30,6 +35,6 @@ const nextConfig = withMDX({
     };
     return config;
   },
-});
+}));
 
 module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest"
+    "test": "jest",
+    "analyze": "ANALYZE=true next build",
+    "lighthouse": "node scripts/lighthouse.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -39,6 +41,7 @@
     "zod": "^4.1.11"
   },
   "devDependencies": {
+    "@next/bundle-analyzer": "^15.5.4",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",
@@ -47,10 +50,13 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.4.20",
+    "chrome-launcher": "^1.2.1",
     "eslint": "^8.57.1",
     "eslint-config-next": "^14.2.15",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "lighthouse": "^12.8.2",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
     "ts-jest": "^29.2.5",

--- a/scripts/lighthouse.js
+++ b/scripts/lighthouse.js
@@ -1,0 +1,33 @@
+// ABOUTME: Simple Lighthouse runner for local URLs
+// ABOUTME: Launches Chrome and audits key routes for scores
+/* eslint-disable no-console */
+const lighthouse = require('lighthouse');
+const chromeLauncher = require('chrome-launcher');
+
+async function runLighthouse(url) {
+  const chrome = await chromeLauncher.launch({ chromeFlags: ['--headless'] });
+  const options = { logLevel: 'info', output: 'json', port: chrome.port };
+  const config = { extends: 'lighthouse:default' };
+  const runnerResult = await lighthouse(url, options, config);
+  await chrome.kill();
+  const { lhr } = runnerResult;
+  console.log(`Lighthouse for ${url}`);
+  console.log('Performance:', Math.round(lhr.categories.performance.score * 100));
+  console.log('Accessibility:', Math.round(lhr.categories.accessibility.score * 100));
+  console.log('Best Practices:', Math.round(lhr.categories['best-practices'].score * 100));
+  console.log('SEO:', Math.round(lhr.categories.seo.score * 100));
+}
+
+async function main() {
+  const base = process.argv[2] || 'http://localhost:3000';
+  const paths = ['/', '/features', '/pricing', '/blog', '/resources', '/podcast', '/videos'];
+  for (const p of paths) {
+    await runLighthouse(`${base}${p}`);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+


### PR DESCRIPTION
This PR advances Phase 5 optimization across performance, SEO, and a11y.\n\nWhat’s included\n- Bundle analyzer\n  - Integrate @next/bundle-analyzer in next.config.js (with MDX).\n  - Enable gzip compression; remove powered-by header.\n  - Script: `npm run analyze`.\n\n- Structured data\n  - Add components/StructuredData.tsx helper.\n  - Inject Organization JSON-LD in app/layout.tsx using NEXT_PUBLIC_SITE_URL.\n\n- SEO consistency\n  - Blog post metadata uses absolute canonical and OG/Twitter image URLs (NEXT_PUBLIC_SITE_URL).\n\n- A11y lint groundwork\n  - Enable eslint-plugin-jsx-a11y (recommended) and surface issues as warnings initially.\n\n- Lighthouse\n  - scripts/lighthouse.js to audit key routes locally or against a deployed URL.\n  - Script: `npm run lighthouse` (pass base URL optionally).\n\n- RSS route stability\n  - Mark blog/podcast RSS XML routes as dynamic to avoid static gen conflicts.\n\nVerification\n- npm run lint: passes (a11y warnings expected).\n- npm run build: successful.\n- npm run analyze: builds with analyzer enabled.\n- npm run lighthouse: prints category scores.\n\nNext candidates\n- Address a11y warnings (Modal, StepIndicator, Carousel, labels).\n- Consider moving sitemap/robots to next-sitemap only if needed (current app routes are sufficient).\n- Add minimal Playwright smoke tests (nav + form flow).\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added site-wide Organization JSON‑LD to improve SEO and rich results.

- Bug Fixes
  - More reliable blog post discovery by slug/path matching.

- Performance
  - Enabled HTTP compression and removed the X‑Powered‑By header.
  - RSS feeds configured to always serve fresh content.

- Chores
  - Introduced accessibility linting rules.
  - Added bundle analysis and Lighthouse audit scripts.
  - Updated development tooling and dev dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->